### PR TITLE
Implement sqrt

### DIFF
--- a/src/m.rs
+++ b/src/m.rs
@@ -3,7 +3,7 @@
 extern "C" {
     // pub fn atan(x: f64) -> f64;
     // pub fn atan2(y: f64, x: f64) -> f64;
-    // pub fn sqrt(x: f64) -> f64;
+    pub fn sqrt(x: f64) -> f64;
     pub fn atan2f(y: f32, x: f32) -> f32;
     pub fn atanf(x: f32) -> f32;
     pub fn fabs(x: f64) -> f64;


### PR DESCRIPTION
The is a rather brutish port of the openlibm code. I'm not sure that all
the casts and wrapping operations reproduce the exact behavior of the C
code. The tests are failing with small differences to the libm results.

Parts of the code still need to be rewritten to be endian independent.